### PR TITLE
修复多斜杠url匹配问题

### DIFF
--- a/src/swagger/index.js
+++ b/src/swagger/index.js
@@ -43,6 +43,8 @@ class Swagger {
 
   getPath (url) {
     return _.find(this.pathObjects, (pathObject) => {
+      // The / at the end will match successfully in the express routing rule base
+      url = url.replace(new RegExp(`${this.basePathPrefix}/{1,2}`), `${this.basePathPrefix}/`)
       return _.isArray(pathObject.regexp.exec(url))
     })
   }


### PR DESCRIPTION
当请求为 //test 时候能进入 route 而为被 middleware 处理导致 req.user 不存在抛出异常问题