### PR TITLE
修复多斜杠url匹配问题

### DIFF
--- a/src/swagger/index.js
+++ b/src/swagger/index.js
@@ -42,9 +42,9 @@ class Swagger {
   }
 
   getPath (url) {
+    url = url.replace(new RegExp(`${this.basePathPrefix}/{1,2}`), `${this.basePathPrefix}/`)
     return _.find(this.pathObjects, (pathObject) => {
       // The / at the end will match successfully in the express routing rule base
-      url = url.replace(new RegExp(`${this.basePathPrefix}/{1,2}`), `${this.basePathPrefix}/`)
       return _.isArray(pathObject.regexp.exec(url))
     })
   }

--- a/src/swagger/index.js
+++ b/src/swagger/index.js
@@ -43,7 +43,6 @@ class Swagger {
 
   getPath (url) {
     // The / at the end will match successfully in the express routing rule base
-    // 验证
     url = url.replace(new RegExp(`${this.basePathPrefix}/{1,2}`), `${this.basePathPrefix}/`)
     return _.find(this.pathObjects, (pathObject) => {
       return _.isArray(pathObject.regexp.exec(url))

--- a/src/swagger/index.js
+++ b/src/swagger/index.js
@@ -42,9 +42,9 @@ class Swagger {
   }
 
   getPath (url) {
+    // The / at the end will match successfully in the express routing rule base
     url = url.replace(new RegExp(`${this.basePathPrefix}/{1,2}`), `${this.basePathPrefix}/`)
     return _.find(this.pathObjects, (pathObject) => {
-      // The / at the end will match successfully in the express routing rule base
       return _.isArray(pathObject.regexp.exec(url))
     })
   }

--- a/src/swagger/index.js
+++ b/src/swagger/index.js
@@ -43,6 +43,7 @@ class Swagger {
 
   getPath (url) {
     // The / at the end will match successfully in the express routing rule base
+    // 验证
     url = url.replace(new RegExp(`${this.basePathPrefix}/{1,2}`), `${this.basePathPrefix}/`)
     return _.find(this.pathObjects, (pathObject) => {
       return _.isArray(pathObject.regexp.exec(url))

--- a/src/swagger/index.js
+++ b/src/swagger/index.js
@@ -43,6 +43,7 @@ class Swagger {
 
   getPath (url) {
     // The / at the end will match successfully in the express routing rule base
+    
     url = url.replace(new RegExp(`${this.basePathPrefix}/{1,2}`), `${this.basePathPrefix}/`)
     return _.find(this.pathObjects, (pathObject) => {
       return _.isArray(pathObject.regexp.exec(url))

--- a/src/swagger/index.js
+++ b/src/swagger/index.js
@@ -43,6 +43,8 @@ class Swagger {
 
   getPath (url) {
     return _.find(this.pathObjects, (pathObject) => {
+      // The / at the end will match successfully in the express routing rule base
+      url = url.replace(new RegExp(`${this.basePathPrefix}/{1,2}`), `${this.basePathPrefix}/`)
       return _.isArray(pathObject.regexp.exec(url))
     })
   }


### PR DESCRIPTION
问题：当类似 //test 等多个斜杠的 url 请求过来，会进入 route 而无法进入 swagger 中的 middleware 进行处理。
导致类似 req.user 不存在，等异常 error 抛出。
处理方式： 将 baseUrl 中的多斜杠 url 处理成单斜杠