### PR TITLE
修复多斜杠url匹配问题

### DIFF
--- a/src/swagger/index.js
+++ b/src/swagger/index.js
@@ -42,6 +42,8 @@ class Swagger {
   }
 
   getPath (url) {
+    // The / at the end will match successfully in the express routing rule base
+    url = url.replace(new RegExp(`${this.basePathPrefix}/{1,2}`), `${this.basePathPrefix}/`)
     return _.find(this.pathObjects, (pathObject) => {
       return _.isArray(pathObject.regexp.exec(url))
     })


### PR DESCRIPTION
问题：类似 //test 的 url 的 url 请求会匹配到 route，而无法匹配到 swagger 中的 middleware，导致 req.user undefind，之类的异常 erro 抛出。
解决： 将 baseUrl 双斜杠在匹配 middleware 转换成单斜杠。